### PR TITLE
Remove deprecated second parameter of asset_url

### DIFF
--- a/lib/css_sprite/sprite.rb
+++ b/lib/css_sprite/sprite.rb
@@ -183,7 +183,7 @@ class Sprite
 
         f.print class_names(results).join(",\n")
         if @config['use_asset_url']
-          f.print " \n  background: asset-url('#{dest_image_name}', image) no-repeat\n"
+          f.print " \n  background: asset-url('#{dest_image_name}') no-repeat\n"
         else
           f.print " \n  background: url('/#{@css_images_path}/#{dest_image_name}?#{dest_image_time.to_i}') no-repeat\n"
         end
@@ -219,7 +219,7 @@ class Sprite
 
         f.print class_names(results).join(",\n")
         if @config['use_asset_url']
-          f.print " \{\n  background: asset-url('#{dest_image_name}', image) no-repeat;\n\}\n"
+          f.print " \{\n  background: asset-url('#{dest_image_name}') no-repeat;\n\}\n"
         else
           f.print " \{\n  background: url('/#{@css_images_path}/#{dest_image_name}?#{dest_image_time.to_i}') no-repeat;\n\}\n"
         end


### PR DESCRIPTION
This PR removes the warning from Rails 4 because of deprecated use of asset_url with 2 arguments.

If this doens't suits you, a new config option could do the job, but I'm going with the idea that no new project will use Rails 3, or if it does, that it can work without asset_url.
